### PR TITLE
Avoid duplicates in listing security groups

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/contrail_plugin.py
@@ -272,6 +272,10 @@ class NeutronPluginContrailCoreV2(plugin_base.NeutronPluginContrailCoreBase):
         if (filters is not None and 'project_id' in filters and
                 'tenant_id' not in filters):
             filters['tenant_id'] = filters['project_id']
+        if (filters is not None and 'project_id' in filters and
+                'tenant_id' in filters):
+            if (filters['project_id'] == filters['tenant_id']):
+                filters.pop('tenant_id')
         resource_dict = {}
         if resource_id:
             resource_dict['id'] = resource_id


### PR DESCRIPTION
The current code does not handle the case when the OpenStack client sends both tenant_id and project ID in the request. Which is the case right now in the latest OpenStack client library.
This handles that case and resolves the problem of getting duplicate security groups when listing it using the latest OpenStack client library.